### PR TITLE
feat: add linter for error/trace/log messages

### DIFF
--- a/cmd/lintroller/lintroller.go
+++ b/cmd/lintroller/lintroller.go
@@ -14,6 +14,7 @@ import (
 	"github.com/getoutreach/lintroller/internal/config"
 	"github.com/getoutreach/lintroller/internal/copyright"
 	"github.com/getoutreach/lintroller/internal/doculint"
+	"github.com/getoutreach/lintroller/internal/errorlint"
 	"github.com/getoutreach/lintroller/internal/header"
 	"github.com/getoutreach/lintroller/internal/todo"
 	"github.com/getoutreach/lintroller/internal/why"
@@ -67,6 +68,7 @@ func main() {
 				cfg.Doculint.ValidateConstants, cfg.Doculint.ValidateTypes)},
 			{cfg.Todo.Enabled, &todo.Analyzer},
 			{cfg.Why.Enabled, &why.Analyzer},
+			{cfg.Errorlint.Enabled, &errorlint.Analyzer},
 		}
 
 		var analyzers []*analysis.Analyzer
@@ -88,5 +90,6 @@ func main() {
 		&copyright.Analyzer,
 		&todo.Analyzer,
 		&why.Analyzer,
+		&errorlint.Analyzer,
 	)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,6 +59,7 @@ type Lintroller struct {
 	Doculint  Doculint  `yaml:"doculint"`
 	Todo      Todo      `yaml:"todo"`
 	Why       Why       `yaml:"why"`
+	Errorlint Errorlint `yaml:"errorlint"`
 }
 
 // MarshalLog implements the log.Marshaler interface.
@@ -68,6 +69,7 @@ func (lr *Lintroller) MarshalLog(addField func(key string, value interface{})) {
 	addField("doculint", lr.Doculint)
 	addField("todo", lr.Todo)
 	addField("why", lr.Why)
+	addField("errorlint", lr.Errorlint)
 }
 
 // Header is the configuration type that matches the flags exposed by the header
@@ -172,5 +174,16 @@ type Why struct {
 
 // MarshalLog implements the log.Marshaler interface.
 func (w *Why) MarshalLog(addField func(key string, value interface{})) {
+	addField("enabled", w.Enabled)
+}
+
+// Errorlint is the configuration type that matches the flags exposed by the errorlint linter.
+type Errorlint struct {
+	// Enabled denotes whether or not this linter is enabled. Defaults to true.
+	Enabled bool `yaml:"enabled"`
+}
+
+// MarshalLog implements the log.Marshaler interface.
+func (w *Errorlint) MarshalLog(addField func(key string, value interface{})) {
 	addField("enabled", w.Enabled)
 }

--- a/internal/config/tiers.go
+++ b/internal/config/tiers.go
@@ -49,19 +49,19 @@ func (l *Lintroller) ValidateTier() error {
 	switch strings.ToLower(*l.Tier) {
 	case TierBronze:
 		if err := l.EnsureMinimums(&TierBronzeConfiguration); err != nil {
-			return errors.Wrap(err, "ensure given configuration meets minimum requirments for bronze tier")
+			return errors.Wrap(err, "ensure given configuration meets minimum requirements for bronze tier")
 		}
 	case TierSilver:
 		if err := l.EnsureMinimums(&TierSilverConfiguration); err != nil {
-			return errors.Wrap(err, "ensure given configuration meets minimum requirments for silver tier")
+			return errors.Wrap(err, "ensure given configuration meets minimum requirements for silver tier")
 		}
 	case TierGold:
 		if err := l.EnsureMinimums(&TierGoldConfiguration); err != nil {
-			return errors.Wrap(err, "ensure given configuration meets minimum requirments for gold tier")
+			return errors.Wrap(err, "ensure given configuration meets minimum requirements for gold tier")
 		}
 	case TierPlatinum:
 		if err := l.EnsureMinimums(&TierPlatinumConfiguration); err != nil {
-			return errors.Wrap(err, "ensure given configuration meets minimum requirments for platinum tier")
+			return errors.Wrap(err, "ensure given configuration meets minimum requirements for platinum tier")
 		}
 	default:
 		log.Warn(context.Background(),
@@ -205,6 +205,9 @@ var TierBronzeConfiguration = Lintroller{
 	Why: Why{
 		Enabled: false,
 	},
+	Errorlint: Errorlint{
+		Enabled: false,
+	},
 }
 
 // TierSilverConfiguration is the Lintroller configuration minumums that correspond
@@ -232,6 +235,9 @@ var TierSilverConfiguration = Lintroller{
 		Enabled: true,
 	},
 	Why: Why{
+		Enabled: true,
+	},
+	Errorlint: Errorlint{
 		Enabled: true,
 	},
 }
@@ -263,6 +269,9 @@ var TierGoldConfiguration = Lintroller{
 	Why: Why{
 		Enabled: true,
 	},
+	Errorlint: Errorlint{
+		Enabled: true,
+	},
 }
 
 // TierPlatinumConfiguration is the Lintroller configuration minumums that correspond
@@ -290,6 +299,9 @@ var TierPlatinumConfiguration = Lintroller{
 		Enabled: true,
 	},
 	Why: Why{
+		Enabled: true,
+	},
+	Errorlint: Errorlint{
 		Enabled: true,
 	},
 }

--- a/internal/errorlint/errorlint.go
+++ b/internal/errorlint/errorlint.go
@@ -1,0 +1,140 @@
+// Copyright 2023 Outreach Corporation. All Rights Reserved.
+
+// Description: See package comment for this one file package.
+
+// Package errorlint contains the necessary logic for the error/log/trace linter.
+package errorlint
+
+import (
+	"go/ast"
+	"go/token"
+	"strconv"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/getoutreach/lintroller/internal/common"
+	"github.com/getoutreach/lintroller/internal/reporter"
+	"golang.org/x/tools/go/analysis"
+)
+
+// name defines the name for the errorlint linter.
+const name = "errorlint"
+
+// doc defines the help text for the error linter.
+const doc = `Ensures that each static message in error/trace/log/ is lowercase.
+
+A valid example is the following:
+
+	func foo() { errors.New("org not found in launchdarkly rule")}`
+
+// Analyzer exports the errorlint analyzer (linter).
+var Analyzer = analysis.Analyzer{
+	Name: name,
+	Doc:  doc,
+	Run:  errorlint,
+}
+
+// errorlint defines linter for error/trace/log messages
+func errorlint(_pass *analysis.Pass) (interface{}, error) {
+	// Ignore test packages.
+	if common.IsTestPackage(_pass) {
+		return nil, nil
+	}
+
+	// Wrap _pass with reporter.Pass to take nolint directives into account.
+	pass := reporter.NewPass(name, _pass, reporter.Warn())
+	for _, file := range pass.Files {
+		// Ignore generated files and test files.
+		if common.IsGenerated(file) || common.IsTestFile(pass.Pass, file) {
+			continue
+		}
+	}
+
+	for expr := range pass.TypesInfo.Types {
+		pkgName, isCleanString := lintMessageStrings(expr)
+		if !isCleanString {
+			pass.Reportf(expr.Pos(), "%s message should be lowercase and last char should not be one of \". : ! \\n\"", pkgName)
+		}
+	}
+
+	return nil, nil
+}
+
+// lintMessageStrings examines error/trace/log strings for capitalization and valid ending
+func lintMessageStrings(expr ast.Expr) (string, bool) {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return "", true
+	}
+
+	if !isDotInPkg(call.Fun, "errors", "New") && !isDotInPkg(call.Fun, "errors", "Wrap") &&
+		!isDotInPkg(call.Fun, "errors", "Wrapf") && !isDotInPkg(call.Fun, "log", "Warn") &&
+		!isDotInPkg(call.Fun, "log", "Info") && !isDotInPkg(call.Fun, "log", "Error") &&
+		!isDotInPkg(call.Fun, "trace", "StartSpan") && !isDotInPkg(call.Fun, "trace", "StartCall") {
+		return "", true
+	}
+
+	if len(call.Args) < 1 {
+		return "", true
+	}
+
+	msgIndex := 1
+	if isDotInPkg(call.Fun, "errors", "New") {
+		msgIndex = 0
+	}
+
+	msg, ok := call.Args[msgIndex].(*ast.BasicLit)
+	if !ok || msg.Kind != token.STRING {
+		return "", true
+	}
+
+	msgString, err := strconv.Unquote(msg.Value)
+	if err != nil {
+		return "", false
+	}
+
+	if msgString == "" {
+		return "", true
+	}
+	isClean := isStringFormatted(msgString)
+	return getPkgName(call.Fun), isClean
+}
+
+// isIdent checks if ident string is equal to ast.Ident name
+func isIdent(expr ast.Expr, ident string) bool {
+	id, ok := expr.(*ast.Ident)
+	return ok && id.Name == ident
+}
+
+// hasDotInPkg checks if pkg.function format is followed
+func isDotInPkg(expr ast.Expr, pkg, name string) bool {
+	sel, ok := expr.(*ast.SelectorExpr)
+	return ok && isIdent(sel.X, pkg) && isIdent(sel.Sel, name)
+}
+
+// getPkgName returns package name
+func getPkgName(expr ast.Expr) string {
+	sel, ok := expr.(*ast.SelectorExpr)
+	for _, pkg := range []string{"errors", "log", "trace"} {
+		if ok && isIdent(sel.X, pkg) {
+			return pkg
+		}
+	}
+
+	return ""
+}
+
+// isStringFormatted examines error/trace/log strings for incorrect ending and capitalization
+func isStringFormatted(msg string) bool {
+	last, _ := utf8.DecodeLastRuneInString(msg)
+	if last == '.' || last == ':' || last == '!' || last == '\n' {
+		return false
+	}
+	for _, ch := range msg {
+		if unicode.IsUpper(ch) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -122,7 +122,7 @@ func (p *Pass) Reportf(pos token.Pos, format string, args ...interface{}) {
 	}
 
 	if p.warn {
-		fmt.Printf("%s: %s (%s) [WARNING]", p.Fset.PositionFor(pos, false).String(), fmt.Sprintf(format, args...), p.linter)
+		fmt.Printf("%s: %s (%s) [WARNING]\n", p.Fset.PositionFor(pos, false).String(), fmt.Sprintf(format, args...), p.linter)
 		return
 	}
 	p.Pass.Reportf(pos, format+" (%s)", append(args, p.linter)...)


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR adds linter for error/trace/log messages. This linter checks following-

1. errors.New, trace.StartCall, trace.StartSpan, log.Warn, log.Error, log.Info, errors.Wrap, errors.Wrapf static messages for capitalization
2. check ending of message string in above cases for valid ending (".", ":","!", "\n") not allowed as end character.

<!-- <<Stencil::Block(jiraPrefix)>> -->

**JIRA ID**: XX-XX

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
