### PR TITLE
feat: Moving to go 1.23, fixing .tool-versions/settings.json

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -3,11 +3,10 @@
 # Be EXTREMELY CAREFUL with this. If you override a standard version
 # you are reducing compatibility guarantees.
 ## <<Stencil::Block(toolverOverride)>>
-## <</Stencil::Block>>
-golang 1.22.0
+golang 1.23.0
 nodejs 20.12.2
-protoc 21.5
-terraform 1.5.7
+mage latest
+## <</Stencil::Block>>
 # Note: Versions in this block do not override the default versions above
 # but sometimes you have to declare additional versions of the same tool
 # while leaving the 'default' version intact for the infra.

--- a/.tool-versions
+++ b/.tool-versions
@@ -5,11 +5,11 @@
 ## <<Stencil::Block(toolverOverride)>>
 golang 1.23.0
 nodejs 20.12.2
-mage latest
 ## <</Stencil::Block>>
 # Note: Versions in this block do not override the default versions above
 # but sometimes you have to declare additional versions of the same tool
 # while leaving the 'default' version intact for the infra.
 # The most common case is nodejs.
 ## <<Stencil::Block(toolver)>>
+mage 1.14.0
 ## <</Stencil::Block>>

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,10 +34,4 @@
   "gopls": {
     "build.buildFlags": ["-tags=or_test,or_dev,or_e2e,or_int"]
   },
-  "[terraform]": {
-    "editor.defaultFormatter": "hashicorp.terraform"
-  },
-  "protoc": {
-    "options": ["--proto_path=${workspaceRoot}/api"]
-  }
 }


### PR DESCRIPTION
This fixes lintroller for folks who have upgraded to go 1.23 and getting errors like this:
```
[lint] $ lintroller -config lintroller.yaml ./...
somefile.go:2:1: package requires newer Go version go1.23
-: This application uses version go1.22 of the source-processing packages but runs version go1.23 of 'go list'. It may fail to process source files that rely on newer language features. If so, rebuild the application using a newer version of Go.
```

I also fixed up the tool-versions/settings.json that are unnecessarily pulling in protoc/terraform modules