### PR TITLE
feat(config): add path exclusion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,21 @@ run through
 [unitchecker](https://pkg.go.dev/golang.org/x/tools/go/analysis/unitchecker).
 This makes lintroller compatible with `go vet`, the recommended way to run lintroller.
 
+### Configuration
+
+When lintroller is run with `-config`, configuration is read from the
+`lintroller` YAML key.
+
+`lintroller.exclusions.paths` accepts regex patterns for excluding files and
+packages by path.
+
+```yaml
+lintroller:
+  exclusions:
+    paths:
+      - '(^|/)node_modules(/|$)'
+```
+
 ### Implemented rules
 
 - `copyright` - Checks that files start with a header that matches a regular expression.

--- a/cmd/lintroller/lintroller.go
+++ b/cmd/lintroller/lintroller.go
@@ -7,6 +7,8 @@ import (
 	"flag"
 	"io"
 	"os"
+	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/getoutreach/gobox/pkg/events"
@@ -56,6 +58,11 @@ func main() {
 			"path": configPath,
 		})
 
+		exclusionPaths, err := cfg.Lintroller.CompiledExclusionPaths()
+		if err != nil {
+			log.Fatal(context.Background(), "compile exclusion paths", events.NewErrorInfo(err))
+		}
+
 		table := []struct {
 			Enabled  bool
 			Analyzer *analysis.Analyzer
@@ -72,7 +79,7 @@ func main() {
 		var analyzers []*analysis.Analyzer
 		for i := range table {
 			if table[i].Enabled {
-				analyzers = append(analyzers, table[i].Analyzer)
+				analyzers = append(analyzers, withExclusionPaths(table[i].Analyzer, exclusionPaths))
 			}
 		}
 
@@ -89,4 +96,50 @@ func main() {
 		&todo.Analyzer,
 		&why.Analyzer,
 	)
+}
+
+// withExclusionPaths wraps the given analyzer and skips execution for excluded paths.
+func withExclusionPaths(analyzer *analysis.Analyzer, exclusionPaths []*regexp.Regexp) *analysis.Analyzer {
+	if len(exclusionPaths) == 0 {
+		return analyzer
+	}
+
+	wrapped := *analyzer
+	wrapped.Run = func(pass *analysis.Pass) (interface{}, error) {
+		if isExcludedPass(pass, exclusionPaths) {
+			return nil, nil
+		}
+
+		return analyzer.Run(pass)
+	}
+
+	return &wrapped
+}
+
+// isExcludedPass reports whether the analysis pass should be skipped due to exclusions.
+func isExcludedPass(pass *analysis.Pass, exclusionPaths []*regexp.Regexp) bool {
+	if matchesAnyExclusion(pass.Pkg.Path(), exclusionPaths) {
+		return true
+	}
+
+	for _, file := range pass.Files {
+		filename := pass.Fset.Position(file.Pos()).Filename
+		if matchesAnyExclusion(filename, exclusionPaths) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// matchesAnyExclusion reports whether a path matches any configured exclusion pattern.
+func matchesAnyExclusion(path string, exclusionPaths []*regexp.Regexp) bool {
+	normalizedPath := strings.ReplaceAll(filepath.ToSlash(path), "\\", "/")
+	for _, exclusionPath := range exclusionPaths {
+		if exclusionPath.MatchString(normalizedPath) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/cmd/lintroller/lintroller_test.go
+++ b/cmd/lintroller/lintroller_test.go
@@ -1,0 +1,35 @@
+// Copyright 2022 Outreach Corporation. Licensed under the Apache License 2.0.
+
+package main
+
+import (
+	"regexp"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestMatchesAnyExclusion(t *testing.T) {
+	t.Parallel()
+
+	t.Run("matches normalized windows paths", func(t *testing.T) {
+		t.Parallel()
+
+		exclusions := []*regexp.Regexp{regexp.MustCompile(`(^|/)node_modules(/|$)`)}
+		assert.Assert(t, matchesAnyExclusion(`foo\\node_modules\\bar\\file.go`, exclusions))
+	})
+
+	t.Run("matches unix style paths", func(t *testing.T) {
+		t.Parallel()
+
+		exclusions := []*regexp.Regexp{regexp.MustCompile(`(^|/)vendor/some-third-party(/|$)`)}
+		assert.Assert(t, matchesAnyExclusion("project/vendor/some-third-party/file.go", exclusions))
+	})
+
+	t.Run("does not match unrelated paths", func(t *testing.T) {
+		t.Parallel()
+
+		exclusions := []*regexp.Regexp{regexp.MustCompile(`(^|/)node_modules(/|$)`)}
+		assert.Assert(t, !matchesAnyExclusion("project/internal/config/config.go", exclusions))
+	})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,7 +8,9 @@
 package config
 
 import (
+	"fmt"
 	"os"
+	"regexp"
 
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
@@ -42,6 +44,10 @@ func FromFile(path string) (*Config, error) {
 		return nil, errors.Wrap(err, "validate the tier given to lintroller")
 	}
 
+	if _, err := cfg.Lintroller.CompiledExclusionPaths(); err != nil {
+		return nil, errors.Wrap(err, "validate lintroller exclusions")
+	}
+
 	return &cfg, nil
 }
 
@@ -53,6 +59,9 @@ type Lintroller struct {
 	// Tier is the desired tier you desire your service to pass for in ops-level.
 	Tier *string `yaml:"tier"`
 
+	// Exclusions holds path matching rules for excluding files and packages.
+	Exclusions Exclusions `yaml:"exclusions"`
+
 	// Configuration for individual linters proceeding:
 	Header    Header    `yaml:"header"`
 	Copyright Copyright `yaml:"copyright"`
@@ -63,11 +72,41 @@ type Lintroller struct {
 
 // MarshalLog implements the log.Marshaler interface.
 func (lr *Lintroller) MarshalLog(addField func(key string, value interface{})) {
+	addField("exclusions", lr.Exclusions)
 	addField("header", lr.Header)
 	addField("copyright", lr.Copyright)
 	addField("doculint", lr.Doculint)
 	addField("todo", lr.Todo)
 	addField("why", lr.Why)
+}
+
+// CompiledExclusionPaths compiles exclusions.path patterns into regular expressions.
+func (lr *Lintroller) CompiledExclusionPaths() ([]*regexp.Regexp, error) {
+	if len(lr.Exclusions.Paths) == 0 {
+		return nil, nil
+	}
+
+	compiled := make([]*regexp.Regexp, 0, len(lr.Exclusions.Paths))
+	for i, path := range lr.Exclusions.Paths {
+		re, err := regexp.Compile(path)
+		if err != nil {
+			return nil, fmt.Errorf("invalid exclusions.paths[%d] pattern %q: %w", i, path, err)
+		}
+		compiled = append(compiled, re)
+	}
+
+	return compiled, nil
+}
+
+// Exclusions is the lintroller configuration that allows users to skip files/packages by path.
+type Exclusions struct {
+	// Paths is a list of regular expressions used for excluding files/packages by path.
+	Paths []string `yaml:"paths"`
+}
+
+// MarshalLog implements the log.Marshaler interface.
+func (e *Exclusions) MarshalLog(addField func(key string, value interface{})) {
+	addField("paths", e.Paths)
 }
 
 // Header is the configuration type that matches the flags exposed by the header

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,41 @@
+// Copyright 2022 Outreach Corporation. Licensed under the Apache License 2.0.
+
+package config
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestCompiledExclusionPaths(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns nil for no exclusions", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &Lintroller{}
+		compiled, err := cfg.CompiledExclusionPaths()
+		assert.NilError(t, err)
+		assert.Equal(t, len(compiled), 0)
+	})
+
+	t.Run("compiles valid regex patterns", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &Lintroller{Exclusions: Exclusions{Paths: []string{"(^|/)node_modules(/|$)", "third_party$"}}}
+		compiled, err := cfg.CompiledExclusionPaths()
+		assert.NilError(t, err)
+		assert.Equal(t, len(compiled), 2)
+		assert.Assert(t, compiled[0].MatchString("foo/node_modules/bar"))
+		assert.Assert(t, compiled[1].MatchString("project/third_party"))
+	})
+
+	t.Run("returns error for invalid regex patterns", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &Lintroller{Exclusions: Exclusions{Paths: []string{"("}}}
+		_, err := cfg.CompiledExclusionPaths()
+		assert.ErrorContains(t, err, "invalid exclusions.paths[0] pattern")
+	})
+}


### PR DESCRIPTION
## What this PR does / why we need it

Adds first-class path exclusion support to lintroller configuration so teams can ignore unwanted paths (for example, third-party Go files under `node_modules`) during lintroller analysis.

- Adds `lintroller.exclusions.paths` to config.
- Validates exclusion regex patterns at config load time.
- Applies path exclusions when running analyzers in config mode.
- Adds tests for exclusion matching and config validation.
- Documents usage in the README with a `node_modules` example.

## Jira ID

[DT-5207]

## Notes for your reviewers

- The config naming mirrors golangci-lint style (`exclusions.paths`) while staying under the `lintroller` namespace.
- Exclusion matching normalizes paths for cross-platform behavior.
- Verified with `make test` (lint + unit tests).
- :robot: PR and PR description written with GPT-5.3-Codex via GitHub Copilot.

[DT-5207]: https://outreach-io.atlassian.net/browse/DT-5207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ