### PR TITLE
fix(header): report diagnostics at the package keyword position

### DIFF
--- a/internal/header/header.go
+++ b/internal/header/header.go
@@ -162,7 +162,7 @@ func header(pass *analysis.Pass) (interface{}, error) { //nolint:funlen // Why: 
 			if !valid {
 				// Required field not found, report it.
 				pass.Reportf(
-					0,
+					file.Package,
 					"file \"%s\" does not contain the required header key \"%s\" and corresponding value existing before the package keyword",
 					fp,
 					field)


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

**Symptom**: A header-linter violation printed a finding but make lint still exited 0.

**Cause**: `internal/header/header.go` reports its diagnostic at `token.NoPos` (`pass.Reportf(0, …)`). The go/analysis text printer renders that position as -, so the output line carries no file:line:col — the filename appears only inside the message string. lintroller itself exits 3, but gearbox's `scripts/lintroller.sh` wrapper discards that exit code (`|| true`) and re-derives failure by grepping the output for `\.go:[0-9]`, which a position-less finding never matches.

**Fix**: One line — change the report position from 0 to file.Package (the package keyword), which the function already computes a position from. Findings then print as path/to/file.go:3:1: …, consistent with the todo, why, and doculint linters.

**Result**: Clean packages still exit 0; violating packages exit 3 with a real position, and the gearbox wrapper correctly exits 1. `go build ./...` and `go test ./...` pass.

**Related**, not changed: `copyright.go:193` and `doculint.go:234` use `Reportf(0, …)` and have the same defect.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-5439](https://outreach-io.atlassian.net/browse/DT-5439)

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

To reproduce the error for testing:
* remove `// Description ...` line in `gearbox` repo locally
* use `mise link` to link to local version of lintroller
* run `make lint` on `gearbox` repository
  * if it fails, the fix for `lintroller` worked

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-5439]: https://outreach-io.atlassian.net/browse/DT-5439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ